### PR TITLE
feat: add exact distributed attention primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ triton==3.1.0
     | **page_size** | Default is 128 for H200. Must be set to 64 for A100. | 
     | **cpu_offload** | Choose between `null` (disabled) and `2` (enabled). | 
     | **page_budget** | The number of pages to retrieve for sparse attention. Default is 64. |
+    | **attention_backend** | Optional for `blockwise-tp`: `paged` (default), `distributed_paged`, or `rectangular`. |
+    | **attention_merge_backend** | Optional for `distributed_paged`: `allreduce` (default) or `allgather_ref`. |
+    | **attention_reduce_dtype** | Optional for `distributed_paged`: `float32` (default) or `bf16`. |
+    | **attention_fallback_to_local** | Optional for `distributed_paged`: keep `true` for single-rank smoke tests, set `false` to require an initialized distributed group. |
 
 2. Run the efficiency test script.
 
@@ -458,6 +462,10 @@ def self_attn_forward(self, hidden_states, kv_cache):
 * `SparseKVCache`, `KVCache`: Manages KV cache prefetching and the overall chunk-wise training logic.
 * `ops.flash_paged_topk.py`: Implements the attention computation for sparse paged KV cache. Offloading is transparent to this kernel.
 * `ops.flash_paged_attn.py`: Implements the attention computation for dense paged KV cache. Offloading is transparent to this kernel.
+* `modifiers.blockwise_attention.py`: Dispatches chunk-wise training attention backends, including dense paged, distributed paged, and rectangular exact reference attention.
+* `ops.distributed_attention.py`: Merges shard-local exact attention outputs using log-sum-exp statistics.
+* `ops.exact_streaming_attn.py`: Provides a PyTorch rectangular online-softmax exact attention reference.
+* `ops.ring_context_parallel.py`: Provides reference online-softmax primitives for ring-style context parallelism.
 
 ---
 

--- a/chunkoptim/cache/kv_cache.py
+++ b/chunkoptim/cache/kv_cache.py
@@ -48,6 +48,16 @@ class SimpleCacheManager:
 
         return page_table
 
+    def page_indices_tensor(self, device=None, for_autograd=False):
+        num_pages = sum(self.last_update_pages)
+        if device is None:
+            device = self.cuda
+        if for_autograd:
+            with torch.inference_mode(False):
+                return torch.arange(num_pages, dtype=torch.int64, device=device)
+        with torch.inference_mode():
+            return torch.arange(num_pages, dtype=torch.int64, device=device)
+
     @property
     @torch.inference_mode()
     def grad(self):
@@ -144,6 +154,12 @@ class SimpleCacheManager:
 
         return key, val
     
+
+class CacheManagerSimple(SimpleCacheManager):
+    def __init__(self, batch_size, page_size, num_kv_heads, head_dim, local_rank=0):
+        super().__init__(
+            batch_size, page_size, num_kv_heads, head_dim, local_rank)
+
 
 class CacheManager(SimpleCacheManager):
     def __init__(self, batch_size, page_size, num_kv_heads, head_dim, local_rank):

--- a/chunkoptim/cache/kv_cache.py
+++ b/chunkoptim/cache/kv_cache.py
@@ -323,10 +323,12 @@ class KVCache:
         num_heads: int = 4,
         head_dim: int = 128,
         cpu_offload=None,
-        local_rank=None):
+        local_rank=None,
+        attention_conf=None):
 
         self.num_layers = num_layers    
         self.cpu_offload = cpu_offload
+        self.attention_conf = attention_conf or {}
 
         MANAGER_CLS = SimpleCacheManager if cpu_offload is None else CacheManager
 
@@ -338,6 +340,8 @@ class KVCache:
                 head_dim,
                 local_rank)
             for _ in range(num_layers)]
+        for manager in self.managers:
+            manager.attention_conf = self.attention_conf
 
     def reset(self):
         for m in self.managers:

--- a/chunkoptim/modifiers/blockwise_attention.py
+++ b/chunkoptim/modifiers/blockwise_attention.py
@@ -1,0 +1,76 @@
+import torch
+
+from ..ops import (
+    flash_paged_attn_distributed_func,
+    flash_paged_attn_func,
+)
+from ..ops.exact_streaming_attn import paged_rectangular_attention
+
+
+def _normalize_backend(name):
+    return str(name).replace("-", "_").lower()
+
+
+def _dtype_from_config(value):
+    if isinstance(value, torch.dtype):
+        return value
+    if value is None:
+        return torch.float32
+    table = {
+        "float32": torch.float32,
+        "fp32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+    }
+    try:
+        return table[str(value).lower()]
+    except KeyError as exc:
+        raise ValueError(
+            "attention reduce_dtype must be one of float32, fp32, "
+            "bfloat16, bf16") from exc
+
+
+def _bool_from_config(value):
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return True
+    text = str(value).strip().lower()
+    if text in ("1", "true", "yes", "on"):
+        return True
+    if text in ("0", "false", "no", "off"):
+        return False
+    raise ValueError("attention fallback_to_local must be a boolean")
+
+
+def resolve_attention_config(manager):
+    raw = getattr(manager, "attention_conf", None) or {}
+    return {
+        "backend": _normalize_backend(raw.get("backend", "paged")),
+        "merge_backend": raw.get("merge_backend", "allreduce"),
+        "reduce_dtype": _dtype_from_config(raw.get("reduce_dtype")),
+        "group": raw.get("group", None),
+        "fallback_to_local": _bool_from_config(raw.get("fallback_to_local", True)),
+        "query_block_size": int(raw.get("query_block_size", 128)),
+        "kv_block_size": int(raw.get("kv_block_size", 128)),
+    }
+
+
+def run_blockwise_attention(query, key, value, manager):
+    config = resolve_attention_config(manager)
+    backend = config["backend"]
+    if backend == "paged":
+        return flash_paged_attn_func(query, key, value, manager)
+    if backend == "distributed_paged":
+        return flash_paged_attn_distributed_func(
+            query, key, value, manager,
+            config["group"],
+            config["reduce_dtype"],
+            config["merge_backend"],
+            config["fallback_to_local"])
+    if backend == "rectangular":
+        return paged_rectangular_attention(
+            query, key, value, manager,
+            query_block_size=config["query_block_size"],
+            kv_block_size=config["kv_block_size"])
+    raise ValueError(f"unsupported blockwise attention backend: {backend}")

--- a/chunkoptim/modifiers/train_baseline_tp.py
+++ b/chunkoptim/modifiers/train_baseline_tp.py
@@ -178,6 +178,9 @@ class ModelForTraining(Modifier):
             layer.forward = types.MethodType(layer_forward, layer)
             layer.self_attn.forward = types.MethodType(self_attn_forward, layer.self_attn)
             layer.mlp.forward = types.MethodType(mlp_forward, layer.mlp)
+            # transformers >=4.43 moved rotary_emb from the attention module to the
+            # model; re-attach a reference so self_attn_forward keeps working.
+            layer.self_attn.rotary_emb = model.model.rotary_emb
 
         if self.conf['lora']['enable']:
             model = self._init_lora(

--- a/chunkoptim/modifiers/train_blockwise_tp.py
+++ b/chunkoptim/modifiers/train_blockwise_tp.py
@@ -174,6 +174,9 @@ class ModelForTraining(Modifier):
             layer.forward = types.MethodType(layer_forward, layer)
             layer.self_attn.forward = types.MethodType(self_attn_forward, layer.self_attn)
             layer.mlp.forward = types.MethodType(mlp_forward, layer.mlp)
+            # transformers >=4.43 moved rotary_emb from the attention module to the
+            # model; re-attach a reference so self_attn_forward keeps working.
+            layer.self_attn.rotary_emb = model.model.rotary_emb
 
         if self.conf['lora']['enable']:
             model = self._init_lora(

--- a/chunkoptim/modifiers/train_blockwise_tp.py
+++ b/chunkoptim/modifiers/train_blockwise_tp.py
@@ -5,8 +5,8 @@ import torch.distributed as dist
 from ..modifier import Modifier
 from .utils import check_and_apply_qk_rope, do_projection
 import torch.nn.functional as F
-from ..ops import flash_paged_attn_func
 from ..ops.all_gather import _AllGather
+from .blockwise_attention import run_blockwise_attention
 from torch.utils.checkpoint import checkpoint
 
 
@@ -140,7 +140,7 @@ def self_attn_forward(self, hidden_states, kv_cache):
     kv_cache[self.layer_idx].update(keys, vals, stage)
     # ================================================
 
-    attn_output = flash_paged_attn_func(
+    attn_output = run_blockwise_attention(
         ques,
         keys,
         vals,

--- a/chunkoptim/ops/__init__.py
+++ b/chunkoptim/ops/__init__.py
@@ -1,4 +1,8 @@
-from .flash_paged_attn import flash_paged_attn_func
+from .flash_paged_attn import (
+    flash_paged_attn_distributed_func,
+    flash_paged_attn_forward_with_lse,
+    flash_paged_attn_func,
+)
 from .flash_paged_topk import flash_paged_sparse_attn_func
 from .flash_paged_moba import flash_paged_moba
 from .flash_attn import flash_attn_func

--- a/chunkoptim/ops/cp_transport.py
+++ b/chunkoptim/ops/cp_transport.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class KVBlock:
+    start: int
+    end: int
+    backend: str
+    owner_rank: int | None = None
+    hop: int = 0
+
+    @property
+    def tokens(self):
+        return self.end - self.start
+
+
+def _validate_schedule_args(num_kv, kv_block_size, world_size=None, rank=None):
+    if num_kv < 1:
+        raise ValueError("num_kv must be >= 1")
+    if kv_block_size < 1:
+        raise ValueError("kv_block_size must be >= 1")
+    if world_size is not None and world_size < 1:
+        raise ValueError("world_size must be >= 1")
+    if rank is not None and (rank < 0 or rank >= world_size):
+        raise ValueError("rank must be in [0, world_size)")
+
+
+def rectangular_kv_schedule(num_kv, kv_block_size):
+    """Return contiguous KV tiles for exact rectangular streaming attention."""
+    _validate_schedule_args(num_kv, kv_block_size)
+    return [
+        KVBlock(start, min(start + kv_block_size, num_kv), "rectangular")
+        for start in range(0, num_kv, kv_block_size)
+    ]
+
+
+def _owned_blocks(num_kv, kv_block_size, world_size, backend):
+    blocks = []
+    for block_idx, start in enumerate(range(0, num_kv, kv_block_size)):
+        owner = block_idx % world_size
+        blocks.append(KVBlock(
+            start=start,
+            end=min(start + kv_block_size, num_kv),
+            backend=backend,
+            owner_rank=owner,
+            hop=0,
+        ))
+    return blocks
+
+
+def ring_kv_schedule(num_kv, kv_block_size, world_size, rank):
+    """Return KV blocks in the owner order a rank would see in a ring pass.
+
+    This is a transport schedule only: it describes which global KV tile is
+    processed at each ring hop. The caller is responsible for the actual
+    send/recv or all-gather implementation.
+    """
+    _validate_schedule_args(num_kv, kv_block_size, world_size, rank)
+    blocks = _owned_blocks(num_kv, kv_block_size, world_size, "ring")
+    ordered = []
+    for hop in range(world_size):
+        owner = (rank - hop) % world_size
+        for block in blocks:
+            if block.owner_rank == owner:
+                ordered.append(KVBlock(
+                    block.start, block.end, block.backend, block.owner_rank, hop))
+    return ordered
+
+
+def usp_kv_schedule(num_kv, kv_block_size, world_size, rank):
+    """Return a Ulysses-style schedule with global tile order and rank owners.
+
+    USP-style implementations can keep global block order while using separate
+    collectives to materialize remote KV tiles. The `hop` field is therefore a
+    distance hint rather than a strict ring step.
+    """
+    _validate_schedule_args(num_kv, kv_block_size, world_size, rank)
+    blocks = _owned_blocks(num_kv, kv_block_size, world_size, "usp")
+    scheduled = []
+    for block in blocks:
+        distance = min(
+            (rank - block.owner_rank) % world_size,
+            (block.owner_rank - rank) % world_size,
+        )
+        scheduled.append(KVBlock(
+            block.start, block.end, block.backend, block.owner_rank, distance))
+    return scheduled

--- a/chunkoptim/ops/distributed_attention.py
+++ b/chunkoptim/ops/distributed_attention.py
@@ -1,0 +1,155 @@
+"""Exact distributed attention output merge helpers.
+
+The local paged attention kernel returns a normalized output for the KV shard
+owned by one rank plus that shard's row-wise log-sum-exp. These helpers merge
+those shard-local results into the exact dense-attention output without moving
+KV blocks between ranks.
+"""
+from __future__ import annotations
+
+import torch
+
+
+def sanitize_empty_attention_output(local_output: torch.Tensor,
+                                    local_lse: torch.Tensor) -> torch.Tensor:
+    """Zero rows whose local causal shard is empty.
+
+    Empty rows have local LSE = -inf. Some kernels may leave their corresponding
+    output values undefined, so they must be masked before finite checks or
+    weighted sums.
+    """
+    empty = torch.isneginf(local_lse.float())
+    if local_output.ndim == 4:
+        empty = empty.permute(0, 2, 1).unsqueeze(-1)
+    elif local_output.ndim == 5:
+        empty = empty.permute(0, 1, 3, 2).unsqueeze(-1)
+    else:
+        raise ValueError(
+            "local_output must be shaped [batch, query, heads, dim] "
+            "or [shard, batch, query, heads, dim]")
+    return torch.where(empty, torch.zeros_like(local_output), local_output)
+
+
+def combine_attention_outputs_from_lse(
+        local_outputs: torch.Tensor,
+        local_lses: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Stable exact merge of normalized local attention outputs.
+
+    Args:
+        local_outputs: [shard, batch, query, heads, dim]
+        local_lses: [shard, batch, heads, query]
+
+    Returns:
+        (global_output, global_lse), where global_output is normalized by the
+        full KV set represented by all shards.
+    """
+    if local_outputs.ndim != 5:
+        raise ValueError(
+            "local_outputs must be shaped [shard, batch, query, heads, dim]")
+    if local_lses.ndim != 4:
+        raise ValueError(
+            "local_lses must be shaped [shard, batch, heads, query]")
+    if local_outputs.shape[0] != local_lses.shape[0]:
+        raise ValueError(
+            "local_outputs and local_lses must have same shard count")
+
+    local_lses_f = local_lses.float()
+    global_lse = torch.logsumexp(local_lses_f, dim=0)
+    weights = torch.exp(local_lses_f - global_lse.unsqueeze(0))
+    weights = torch.where(
+        torch.isneginf(local_lses_f), torch.zeros_like(weights), weights)
+    weights = weights.permute(0, 1, 3, 2).unsqueeze(-1)
+    local_outputs_f = sanitize_empty_attention_output(
+        local_outputs.float(), local_lses_f)
+    combined = (local_outputs_f * weights).sum(dim=0)
+    return combined.to(local_outputs.dtype), global_lse.to(local_lses.dtype)
+
+
+def distributed_lse_merge_allreduce(
+        local_output: torch.Tensor,
+        local_lse: torch.Tensor,
+        group=None,
+        reduce_dtype: torch.dtype = torch.float32,
+        fallback_to_local: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Merge one rank's local attention shard via exact LSE all-reduces."""
+    if reduce_dtype not in (torch.float32, torch.bfloat16):
+        raise ValueError("reduce_dtype must be torch.float32 or torch.bfloat16")
+
+    import torch.distributed as dist
+
+    local_lse_f = local_lse.float()
+    if fallback_to_local and (
+            (not dist.is_available()) or (not dist.is_initialized())):
+        return combine_attention_outputs_from_lse(
+            local_output.unsqueeze(0), local_lse_f.unsqueeze(0))
+
+    max_lse = local_lse_f.clone()
+    dist.all_reduce(max_lse, op=dist.ReduceOp.MAX, group=group)
+    shifted_exp = torch.exp(local_lse_f - max_lse)
+    shifted_exp = torch.where(
+        torch.isneginf(local_lse_f), torch.zeros_like(shifted_exp), shifted_exp)
+    output = sanitize_empty_attention_output(local_output.float(), local_lse_f)
+    numerator = (
+        output * shifted_exp.permute(0, 2, 1).unsqueeze(-1)
+    ).to(reduce_dtype).contiguous()
+    denominator = shifted_exp.contiguous()
+    dist.all_reduce(numerator, op=dist.ReduceOp.SUM, group=group)
+    dist.all_reduce(denominator, op=dist.ReduceOp.SUM, group=group)
+    denominator = denominator.clamp_min(1e-30)
+    combined = numerator.float() / denominator.permute(0, 2, 1).unsqueeze(-1)
+    global_lse = max_lse + torch.log(denominator)
+    return combined.to(local_output.dtype), global_lse.to(local_lse.dtype)
+
+
+def distributed_lse_merge_allgather_reference(
+        local_output: torch.Tensor,
+        local_lse: torch.Tensor,
+        group=None,
+        fallback_to_local: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference backend: gather all local shard outputs, then merge locally.
+
+    This is intentionally not a performance backend. It is useful for debugging
+    the all-reduce backend because it uses the same mathematical recomposition
+    as the single-process dense-sharded path.
+    """
+    import torch.distributed as dist
+
+    if fallback_to_local and (
+            (not dist.is_available()) or (not dist.is_initialized())):
+        return combine_attention_outputs_from_lse(
+            local_output.unsqueeze(0), local_lse.unsqueeze(0))
+
+    world = dist.get_world_size(group=group)
+    local_output = local_output.contiguous()
+    local_lse = local_lse.contiguous()
+    gathered_outputs = [torch.empty_like(local_output) for _ in range(world)]
+    gathered_lses = [torch.empty_like(local_lse) for _ in range(world)]
+    dist.all_gather(gathered_outputs, local_output, group=group)
+    dist.all_gather(gathered_lses, local_lse, group=group)
+    return combine_attention_outputs_from_lse(
+        torch.stack(gathered_outputs, dim=0),
+        torch.stack(gathered_lses, dim=0))
+
+
+def distributed_lse_merge(
+        local_output: torch.Tensor,
+        local_lse: torch.Tensor,
+        group=None,
+        *,
+        backend: str = "allreduce",
+        reduce_dtype: torch.dtype = torch.float32,
+        fallback_to_local: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Dispatch exact distributed attention merge backend."""
+    if backend == "allreduce":
+        return distributed_lse_merge_allreduce(
+            local_output, local_lse, group=group, reduce_dtype=reduce_dtype,
+            fallback_to_local=fallback_to_local)
+    if backend == "allgather_ref":
+        return distributed_lse_merge_allgather_reference(
+            local_output, local_lse, group=group,
+            fallback_to_local=fallback_to_local)
+    raise ValueError(
+        f"unsupported distributed attention merge backend: {backend}")

--- a/chunkoptim/ops/exact_attn_bench.py
+++ b/chunkoptim/ops/exact_attn_bench.py
@@ -1,0 +1,234 @@
+import argparse
+import json
+import math
+import time
+
+import torch
+
+from chunkoptim.cache.kv_cache import SimpleCacheManager
+from chunkoptim.ops.exact_streaming_attn import (
+    materialize_paged_kv,
+    rectangular_streaming_attention,
+)
+
+
+def _sync(device):
+    if torch.device(device).type == "cuda":
+        torch.cuda.synchronize(torch.device(device))
+
+
+def _dtype_from_name(name):
+    table = {
+        "float32": torch.float32,
+        "fp32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+        "float16": torch.float16,
+        "fp16": torch.float16,
+    }
+    if name not in table:
+        raise ValueError("dtype must be one of float32,bfloat16,float16")
+    return table[name]
+
+
+def _dense_attention_reference(query, key, value, *, q_start, kv_start=0):
+    groups = query.shape[2] // key.shape[2]
+    if groups != 1:
+        key = key.repeat_interleave(groups, dim=2)
+        value = value.repeat_interleave(groups, dim=2)
+    scores = torch.einsum("bqhd,bkhd->bhqk", query.float(), key.float())
+    scores = scores / math.sqrt(query.shape[-1])
+    q_pos = torch.arange(q_start, q_start + query.shape[1], device=query.device)
+    kv_pos = torch.arange(kv_start, kv_start + key.shape[1], device=query.device)
+    allowed = kv_pos.unsqueeze(0) <= q_pos.unsqueeze(1)
+    scores = scores.masked_fill(~allowed.unsqueeze(0).unsqueeze(0), -float("inf"))
+    valid = torch.isfinite(scores).any(dim=-1, keepdim=True)
+    probs = torch.softmax(scores, dim=-1)
+    probs = torch.where(valid, probs, torch.zeros_like(probs))
+    return torch.einsum("bhqk,bkhd->bqhd", probs, value.float()).to(query.dtype)
+
+
+def _time_call(fn, repeat, device):
+    elapsed = []
+    result = None
+    for _ in range(repeat):
+        _sync(device)
+        start = time.perf_counter()
+        result = fn()
+        _sync(device)
+        elapsed.append(time.perf_counter() - start)
+    return result, sum(elapsed) / max(len(elapsed), 1)
+
+
+def _peak_memory_gb(device):
+    dev = torch.device(device)
+    if dev.type != "cuda":
+        return None
+    return torch.cuda.max_memory_allocated(dev) / 1e9
+
+
+def _make_manager(key, value, page_size):
+    dev = key.device
+    local_rank = dev.index if dev.type == "cuda" else 0
+    manager = SimpleCacheManager(
+        key.shape[0], page_size, key.shape[2], key.shape[3],
+        local_rank=local_rank)
+    manager.update(key.to(torch.bfloat16), value.to(torch.bfloat16), stage=1)
+    return manager
+
+
+def run_rectangular_attention_benchmark(
+        *, batch_size, q_len, kv_len, num_heads, num_kv_heads, head_dim,
+        query_block_size, kv_block_size, q_start=None, page_size=None,
+        device="cpu", dtype=torch.float32, seed=0, warmup=1, repeat=3,
+        check_dense=False):
+    if q_start is None:
+        q_start = kv_len - q_len
+    if page_size is None:
+        page_size = kv_block_size
+    if q_start < 0:
+        raise ValueError("q_start must be >= 0")
+    if repeat < 1:
+        raise ValueError("repeat must be >= 1")
+    if warmup < 0:
+        raise ValueError("warmup must be >= 0")
+    if num_heads % num_kv_heads != 0:
+        raise ValueError("num_heads must be divisible by num_kv_heads")
+
+    torch.manual_seed(seed)
+    dev = torch.device(device)
+    query = torch.randn(
+        batch_size, q_len, num_heads, head_dim, device=dev, dtype=dtype)
+    key = torch.randn(
+        batch_size, kv_len, num_kv_heads, head_dim, device=dev, dtype=dtype)
+    value = torch.randn(
+        batch_size, kv_len, num_kv_heads, head_dim, device=dev, dtype=dtype)
+    manager = _make_manager(key, value, page_size)
+
+    if dev.type == "cuda":
+        torch.cuda.reset_peak_memory_stats(dev)
+
+    for _ in range(warmup):
+        key_full, value_full = materialize_paged_kv(manager)
+        rectangular_streaming_attention(
+            query, key_full.to(dtype), value_full.to(dtype),
+            query_block_size=query_block_size,
+            kv_block_size=kv_block_size,
+            causal=True,
+            q_start=q_start,
+            kv_start=0)
+    _sync(dev)
+
+    (key_full, value_full), materialize_avg = _time_call(
+        lambda: materialize_paged_kv(manager), repeat, dev)
+    key_full = key_full.to(dtype)
+    value_full = value_full.to(dtype)
+
+    out, rectangular_avg = _time_call(
+        lambda: rectangular_streaming_attention(
+            query, key_full, value_full,
+            query_block_size=query_block_size,
+            kv_block_size=kv_block_size,
+            causal=True,
+            q_start=q_start,
+            kv_start=0),
+        repeat,
+        dev)
+
+    dense_check = {"enabled": False}
+    if check_dense:
+        ref, dense_s = _time_call(
+            lambda: _dense_attention_reference(
+                query, key_full, value_full, q_start=q_start),
+            1,
+            dev)
+        diff = (out.float() - ref.float()).abs()
+        denom = ref.float().abs().clamp_min(1e-8)
+        dense_check = {
+            "enabled": True,
+            "dense_forward_s": dense_s,
+            "max_abs_error": float(diff.max().item()),
+            "max_rel_error": float((diff / denom).max().item()),
+        }
+
+    query_blocks = math.ceil(q_len / query_block_size)
+    kv_blocks = math.ceil(kv_len / kv_block_size)
+    return {
+        "backend": "rectangular_exact",
+        "device": str(dev),
+        "dtype": str(dtype),
+        "seed": seed,
+        "shape": {
+            "batch_size": batch_size,
+            "q_len": q_len,
+            "kv_len": kv_len,
+            "num_heads": num_heads,
+            "num_kv_heads": num_kv_heads,
+            "head_dim": head_dim,
+        },
+        "tiles": {
+            "query_block_size": query_block_size,
+            "kv_block_size": kv_block_size,
+            "query_blocks": query_blocks,
+            "kv_blocks": kv_blocks,
+            "tile_count": query_blocks * kv_blocks,
+        },
+        "page_size": page_size,
+        "q_start": q_start,
+        "score_cells": batch_size * num_heads * q_len * kv_len,
+        "timing_s": {
+            "materialize_avg": materialize_avg,
+            "rectangular_forward_avg": rectangular_avg,
+        },
+        "peak_memory_gb": _peak_memory_gb(dev),
+        "dense_check": dense_check,
+    }
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--q-len", type=int, default=2048)
+    parser.add_argument("--kv-len", type=int, default=131072)
+    parser.add_argument("--num-heads", type=int, default=24)
+    parser.add_argument("--num-kv-heads", type=int, default=4)
+    parser.add_argument("--head-dim", type=int, default=256)
+    parser.add_argument("--query-block-size", type=int, default=128)
+    parser.add_argument("--kv-block-size", type=int, default=512)
+    parser.add_argument("--page-size", type=int, default=None)
+    parser.add_argument("--q-start", type=int, default=None)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--dtype", default="bfloat16",
+                        choices=["float32", "fp32", "bfloat16", "bf16", "float16", "fp16"])
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--repeat", type=int, default=3)
+    parser.add_argument("--check-dense", action="store_true")
+    return parser
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+    result = run_rectangular_attention_benchmark(
+        batch_size=args.batch_size,
+        q_len=args.q_len,
+        kv_len=args.kv_len,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        head_dim=args.head_dim,
+        query_block_size=args.query_block_size,
+        kv_block_size=args.kv_block_size,
+        q_start=args.q_start,
+        page_size=args.page_size,
+        device=args.device,
+        dtype=_dtype_from_name(args.dtype),
+        seed=args.seed,
+        warmup=args.warmup,
+        repeat=args.repeat,
+        check_dense=args.check_dense,
+    )
+    print("EXACT_ATTN_BENCH_JSON: " + json.dumps(result, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/chunkoptim/ops/exact_streaming_attn.py
+++ b/chunkoptim/ops/exact_streaming_attn.py
@@ -1,0 +1,195 @@
+import math
+
+import torch
+
+
+def _validate_attention_inputs(query, key, value, query_block_size, kv_block_size):
+    if query.ndim != 4 or key.ndim != 4 or value.ndim != 4:
+        raise ValueError("query, key, and value must be shaped [batch, seq, heads, dim]")
+    if key.shape != value.shape:
+        raise ValueError("key and value must have the same shape")
+    if query.shape[0] != key.shape[0]:
+        raise ValueError("query and key/value batch sizes must match")
+    if query.shape[-1] != key.shape[-1]:
+        raise ValueError("query and key/value head dimensions must match")
+    if query.shape[2] % key.shape[2] != 0:
+        raise ValueError("query heads must be divisible by key/value heads")
+    if query_block_size < 1:
+        raise ValueError("query_block_size must be >= 1")
+    if kv_block_size < 1:
+        raise ValueError("kv_block_size must be >= 1")
+
+
+def _expand_gqa(tensor, num_query_heads):
+    groups = num_query_heads // tensor.shape[2]
+    if groups == 1:
+        return tensor
+    return tensor.repeat_interleave(groups, dim=2)
+
+
+def rectangular_streaming_attention(
+        query, key, value, *, query_block_size=128, kv_block_size=128,
+        causal=True, q_start=0, kv_start=0, scale=None, return_lse=False):
+    """Exact dense attention computed as rectangular KV tiles.
+
+    The implementation keeps per-query online-softmax state `(m, l, acc)` and
+    never materializes the full score matrix. It is intentionally written in
+    PyTorch so the math is easy to validate and differentiable; production
+    kernels can later reuse this API contract.
+    """
+    _validate_attention_inputs(
+        query, key, value, query_block_size, kv_block_size)
+    if scale is None:
+        scale = 1.0 / math.sqrt(query.shape[-1])
+
+    batch, q_len, num_heads, head_dim = query.shape
+    kv_len = key.shape[1]
+    out_blocks = []
+    lse_blocks = []
+    key_expanded = _expand_gqa(key, num_heads)
+    value_expanded = _expand_gqa(value, num_heads)
+
+    for q0 in range(0, q_len, query_block_size):
+        q1 = min(q0 + query_block_size, q_len)
+        q_blk = query[:, q0:q1]
+        q_blk_len = q1 - q0
+        m = torch.full(
+            (batch, num_heads, q_blk_len), -float("inf"),
+            device=query.device, dtype=torch.float32)
+        l = torch.zeros(
+            (batch, num_heads, q_blk_len),
+            device=query.device, dtype=torch.float32)
+        acc = torch.zeros(
+            (batch, q_blk_len, num_heads, head_dim),
+            device=query.device, dtype=torch.float32)
+
+        q_pos = None
+        if causal:
+            q_pos = torch.arange(
+                q_start + q0, q_start + q1,
+                device=query.device, dtype=torch.long)
+
+        for k0 in range(0, kv_len, kv_block_size):
+            k1 = min(k0 + kv_block_size, kv_len)
+            k_blk = key_expanded[:, k0:k1]
+            v_blk = value_expanded[:, k0:k1]
+            scores = torch.einsum(
+                "bqhd,bkhd->bhqk", q_blk.float(), k_blk.float())
+            scores = scores * scale
+
+            if causal:
+                kv_pos = torch.arange(
+                    kv_start + k0, kv_start + k1,
+                    device=query.device, dtype=torch.long)
+                allowed = kv_pos.unsqueeze(0) <= q_pos.unsqueeze(1)
+                scores = scores.masked_fill(
+                    ~allowed.unsqueeze(0).unsqueeze(0), -float("inf"))
+
+            tile_has_value = torch.isfinite(scores).any(dim=-1)
+            tile_m = torch.max(scores, dim=-1).values
+            tile_m_safe = torch.where(
+                tile_has_value, tile_m, torch.zeros_like(tile_m))
+            exp_scores = torch.exp(scores - tile_m_safe.unsqueeze(-1))
+            exp_scores = torch.where(
+                torch.isfinite(scores), exp_scores, torch.zeros_like(exp_scores))
+            tile_l = exp_scores.sum(dim=-1)
+            tile_acc = torch.einsum(
+                "bhqk,bkhd->bqhd", exp_scores, v_blk.float())
+
+            new_m = torch.maximum(m, tile_m)
+            new_valid = torch.isfinite(new_m)
+            m_scale = torch.where(
+                torch.isfinite(m),
+                torch.exp(m - torch.where(new_valid, new_m, torch.zeros_like(new_m))),
+                torch.zeros_like(m),
+            )
+            tile_scale = torch.where(
+                tile_has_value,
+                torch.exp(tile_m - torch.where(new_valid, new_m, torch.zeros_like(new_m))),
+                torch.zeros_like(tile_m),
+            )
+            acc = (
+                acc * m_scale.permute(0, 2, 1).unsqueeze(-1)
+                + tile_acc * tile_scale.permute(0, 2, 1).unsqueeze(-1)
+            )
+            l = l * m_scale + tile_l * tile_scale
+            m = new_m
+
+        denom = l.clamp_min(1e-30)
+        out = acc / denom.permute(0, 2, 1).unsqueeze(-1)
+        valid = l > 0
+        out = torch.where(
+            valid.permute(0, 2, 1).unsqueeze(-1),
+            out,
+            torch.zeros_like(out),
+        )
+        out_blocks.append(out.to(query.dtype))
+
+        lse = torch.where(valid, m + torch.log(denom), torch.full_like(m, -float("inf")))
+        lse_blocks.append(lse)
+
+    out = torch.cat(out_blocks, dim=1)
+    if not return_lse:
+        return out
+    return out, torch.cat(lse_blocks, dim=-1).to(torch.float32)
+
+
+def materialize_paged_kv(manager):
+    """Concatenate a paged KV cache into contiguous `[B, K, H, D]` tensors."""
+    if manager.num_kv < 1:
+        raise ValueError("manager must contain at least one KV token")
+    if len(manager.key_gpu) != len(manager.val_gpu):
+        raise ValueError("manager key/value page counts differ")
+    if not manager.key_gpu:
+        raise ValueError("manager has no resident KV pages")
+    key = torch.cat(manager.key_gpu, dim=1)[:, :manager.num_kv].contiguous()
+    value = torch.cat(manager.val_gpu, dim=1)[:, :manager.num_kv].contiguous()
+    return key, value
+
+
+class PagedRectangularAttention(torch.autograd.Function):
+    @staticmethod
+    def forward(
+            ctx, query, key_current, value_current, manager,
+            query_block_size, kv_block_size):
+        key_full, value_full = materialize_paged_kv(manager)
+        query_detached = query.detach().requires_grad_(True)
+        key_full_detached = key_full.detach().requires_grad_(True)
+        value_full_detached = value_full.detach().requires_grad_(True)
+        with torch.enable_grad():
+            output = rectangular_streaming_attention(
+                query_detached, key_full_detached, value_full_detached,
+                query_block_size=query_block_size,
+                kv_block_size=kv_block_size,
+                causal=True,
+                q_start=manager.num_kv - query.shape[1],
+                kv_start=0,
+            )
+        ctx.save_for_backward(
+            query_detached, key_full_detached, value_full_detached, output)
+        ctx.current_tokens = key_current.shape[1]
+        return output.detach()
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        query, key_full, value_full, output = ctx.saved_tensors
+        dq, dk_full, dv_full = torch.autograd.grad(
+            output,
+            (query, key_full, value_full),
+            grad_output,
+            retain_graph=False,
+            allow_unused=False,
+        )
+        current = ctx.current_tokens
+        dk_current = dk_full[:, -current:].to(dtype=grad_output.dtype)
+        dv_current = dv_full[:, -current:].to(dtype=grad_output.dtype)
+        return dq.to(dtype=grad_output.dtype), dk_current, dv_current, None, None, None
+
+
+def paged_rectangular_attention(
+        query, key_current, value_current, manager, *,
+        query_block_size=128, kv_block_size=128):
+    """Autograd-compatible rectangular exact attention over a paged manager."""
+    return PagedRectangularAttention.apply(
+        query, key_current, value_current, manager,
+        int(query_block_size), int(kv_block_size))

--- a/chunkoptim/ops/flash_paged_attn.py
+++ b/chunkoptim/ops/flash_paged_attn.py
@@ -757,7 +757,8 @@ class DistributedFlashPagedAttn(torch.autograd.Function):
     @staticmethod
     def forward(
             ctx, q, k, v, manager, group=None,
-            reduce_dtype=torch.float32, merge_backend="allreduce"):
+            reduce_dtype=torch.float32, merge_backend="allreduce",
+            fallback_to_local=True):
         import torch.distributed as dist
 
         q = q if q.stride(-1) == 1 else q.contiguous()
@@ -791,11 +792,14 @@ class DistributedFlashPagedAttn(torch.autograd.Function):
         out, global_lse = distributed_lse_merge(
             local_out, local_lse, group=group,
             backend=merge_backend, reduce_dtype=reduce_dtype,
-            fallback_to_local=False)
+            fallback_to_local=fallback_to_local)
         ctx.save_for_backward(q, out, global_lse, page_indices)
         ctx.manager = manager
         ctx.group = group
         ctx.softmax_scale = softmax_scale
+        ctx.needs_dq_all_reduce = (
+            dist.is_available() and dist.is_initialized()
+            and dist.get_world_size(group=group) > 1)
         return out
 
     @staticmethod
@@ -816,9 +820,10 @@ class DistributedFlashPagedAttn(torch.autograd.Function):
                 ctx.manager.num_kv - q.shape[1],
                 global_lse,
                 ctx.softmax_scale)
-        dist.all_reduce(dq, op=dist.ReduceOp.SUM, group=ctx.group)
+        if ctx.needs_dq_all_reduce:
+            dist.all_reduce(dq, op=dist.ReduceOp.SUM, group=ctx.group)
         dk, dv = ctx.manager.grad
-        return dq, dk, dv, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None
 
 
 flash_paged_attn_distributed_func = DistributedFlashPagedAttn.apply

--- a/chunkoptim/ops/flash_paged_attn.py
+++ b/chunkoptim/ops/flash_paged_attn.py
@@ -4,7 +4,15 @@ import torch
 import triton
 import triton.language as tl
 
+from .distributed_attention import distributed_lse_merge
 from .utils import IS_BF16_ATOM_ADD_SUPPORTED
+
+
+def validate_flash_paged_head_dim(head_dim: int):
+    if head_dim > 256:
+        raise ValueError(
+            f"flash paged attention head_dim must be <= 256, got {head_dim}")
+
 
 @triton.jit
 def _bwd_preprocess_do_o_dot(
@@ -158,6 +166,95 @@ def _fwd_kernel(
 
 
 @triton.jit
+def _fwd_indexed_kernel(
+    Q, T, PageIndices,
+    Out, Lse,
+    softmax_scale,
+    stride_qb, stride_qh, stride_qm,
+    stride_ob, stride_oh, stride_om,
+    stride_kvb, stride_kvh, stride_kvn,
+    nheads, seqlen_q, q_start_idx, headdim,
+    seqlen_q_rounded, total_seqlen_k, num_pages, num_kv_heads,
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    BLOCK_HEADDIM: tl.constexpr,
+    EVEN_M: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+):
+    start_m_block = tl.program_id(0)
+    off_hb = tl.program_id(1)
+    off_b = off_hb // nheads
+    off_h = off_hb % nheads
+    off_kv_h = off_h // GROUP_SIZE
+
+    offs_m = start_m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, BLOCK_HEADDIM)
+
+    q_ptrs = Q + off_b * stride_qb + off_h * stride_qh + (offs_m[:, None] * stride_qm + offs_d[None, :])
+    kv_offs = off_b * stride_kvb + off_kv_h * stride_kvh + (offs_n[:, None] * stride_kvn + offs_d[None, :])
+
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    lse_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    acc_o = tl.zeros([BLOCK_M, BLOCK_HEADDIM], dtype=tl.float32)
+
+    if EVEN_M:
+        q = tl.load(q_ptrs)
+    else:
+        q = tl.load(q_ptrs, mask=offs_m[:, None] < seqlen_q, other=0.0)
+
+    q_idx = q_start_idx + offs_m
+    invalid_score = -1.0e20
+
+    for page_pos in tl.range(0, num_pages):
+        page_index = tl.load(PageIndices + page_pos)
+        k_idx = page_index * BLOCK_N + offs_n
+        kv_mask = k_idx < total_seqlen_k
+
+        k_page_ptr = tl.load(T + page_pos * 4)
+        v_page_ptr = tl.load(T + page_pos * 4 + 1)
+
+        k_page_ptr = tl.cast(k_page_ptr, tl.pointer_type(tl.bfloat16))
+        v_page_ptr = tl.cast(v_page_ptr, tl.pointer_type(tl.bfloat16))
+
+        k = tl.load(k_page_ptr + kv_offs, mask=kv_mask[:, None], other=0.0)
+        v = tl.load(v_page_ptr + kv_offs, mask=kv_mask[:, None], other=0.0)
+
+        qk = tl.dot(q, k.T)
+        causal = q_idx[:, None] >= k_idx[None, :]
+        valid = causal & kv_mask[None, :]
+        qk = tl.where(valid, qk, invalid_score)
+
+        m_ij = tl.maximum(tl.max(qk, 1) * softmax_scale, m_i)
+        p = tl.exp(qk * softmax_scale - m_ij[:, None])
+        p = tl.where(valid, p, 0.0)
+        l_ij = tl.sum(p, 1)
+
+        acc_o_scale = tl.exp(m_i - m_ij)
+        acc_o = acc_o * acc_o_scale[:, None]
+        p = p.to(v.dtype)
+        acc_o += tl.dot(p, v)
+
+        m_i = m_ij
+        l_i_new = tl.exp(lse_i - m_ij) + l_ij
+        lse_i = m_ij + tl.log(l_i_new)
+
+    lse_finite = lse_i == lse_i
+    o_scale = tl.exp(m_i - lse_i)
+    o_scale = tl.where(lse_finite, o_scale, 0.0)
+    acc_o = acc_o * o_scale[:, None]
+
+    lse_ptrs = Lse + off_hb * seqlen_q_rounded + offs_m
+    tl.store(lse_ptrs, lse_i, mask=offs_m < seqlen_q)
+
+    out_ptrs = Out + off_b * stride_ob + off_h * stride_oh + (offs_m[:, None] * stride_om + offs_d[None, :])
+
+    if EVEN_M:
+        tl.store(out_ptrs, acc_o)
+    else:
+        tl.store(out_ptrs, acc_o, mask=offs_m[:, None] < seqlen_q)
+
+
+@triton.jit
 def _bwd_kernel(
     Q, DO, DQ, T,
     LSE, D,
@@ -258,6 +355,104 @@ def _bwd_kernel(
         tl.store(dq_ptrs, dq_block, mask=mask_m[:, None])
 
 
+@triton.jit
+def _bwd_indexed_kernel(
+    Q, DO, DQ, T, PageIndices,
+    LSE, D,
+    softmax_scale,
+    stride_qb, stride_qh, stride_qm,
+    stride_kvb, stride_kvh, stride_kvn,
+    stride_dob, stride_doh, stride_dom,
+    stride_dqb, stride_dqh, stride_dqm,
+    nheads, seqlen_q, q_start_idx, headdim,
+    seqlen_q_rounded, total_seqlen_k, num_pages, num_kv_heads,
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    BLOCK_HEADDIM: tl.constexpr,
+    EVEN_M: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    FP32_ATOMIC_ADD: tl.constexpr,
+):
+    start_m_block = tl.program_id(0)
+    off_hb = tl.program_id(1)
+    off_b = off_hb // nheads
+    off_h = off_hb % nheads
+    off_kv_h = off_h // GROUP_SIZE
+
+    offs_m = start_m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, BLOCK_HEADDIM)
+
+    q_ptrs = Q + off_b * stride_qb + off_h * stride_qh + (offs_m[:, None] * stride_qm + offs_d[None, :])
+    kv_offs = off_b * stride_kvb + off_kv_h * stride_kvh + (offs_n[:, None] * stride_kvn + offs_d[None, :])
+    do_ptrs = DO + off_b * stride_dob + off_h * stride_doh + (offs_m[:, None] * stride_dom + offs_d[None, :])
+    dq_ptrs = DQ + off_b * stride_dqb + off_h * stride_dqh + (offs_m[:, None] * stride_dqm + offs_d[None, :])
+
+    lse_ptrs = LSE + off_hb * seqlen_q_rounded + offs_m
+    d_ptrs = D + off_hb * seqlen_q_rounded + offs_m
+
+    mask_m = offs_m < seqlen_q
+    if EVEN_M:
+        q = tl.load(q_ptrs)
+        do = tl.load(do_ptrs)
+        lse_i = tl.load(lse_ptrs)
+        Di = tl.load(d_ptrs)
+    else:
+        q = tl.load(q_ptrs, mask=mask_m[:, None], other=0.0)
+        do = tl.load(do_ptrs, mask=mask_m[:, None], other=0.0)
+        lse_i = tl.load(lse_ptrs, mask=mask_m, other=0.0)
+        Di = tl.load(d_ptrs, mask=mask_m, other=0.0)
+
+    dq_block = tl.zeros([BLOCK_M, BLOCK_HEADDIM], dtype=tl.float32)
+    q_idx = q_start_idx + offs_m
+
+    for page_pos in tl.range(0, num_pages):
+        page_index = tl.load(PageIndices + page_pos)
+        k_idx = page_index * BLOCK_N + offs_n
+        kv_mask_1d = k_idx < total_seqlen_k
+        kv_mask = kv_mask_1d[:, None]
+
+        k_page_ptr = tl.load(T + page_pos * 4)
+        v_page_ptr = tl.load(T + page_pos * 4 + 1)
+        dk_page_ptr = tl.load(T + page_pos * 4 + 2)
+        dv_page_ptr = tl.load(T + page_pos * 4 + 3)
+
+        k_page_ptr = tl.cast(k_page_ptr, tl.pointer_type(tl.bfloat16))
+        v_page_ptr = tl.cast(v_page_ptr, tl.pointer_type(tl.bfloat16))
+        if FP32_ATOMIC_ADD:
+            dk_page_ptr = tl.cast(dk_page_ptr, tl.pointer_type(tl.float32))
+            dv_page_ptr = tl.cast(dv_page_ptr, tl.pointer_type(tl.float32))
+        else:
+            dk_page_ptr = tl.cast(dk_page_ptr, tl.pointer_type(tl.bfloat16))
+            dv_page_ptr = tl.cast(dv_page_ptr, tl.pointer_type(tl.bfloat16))
+
+        k = tl.load(k_page_ptr + kv_offs, mask=kv_mask, other=0.0)
+        v = tl.load(v_page_ptr + kv_offs, mask=kv_mask, other=0.0)
+
+        qk = tl.dot(q, k.T)
+        causal = q_idx[:, None] >= k_idx[None, :]
+        valid = causal & kv_mask_1d[None, :]
+        qk = tl.where(valid, qk, -1.0e20)
+
+        p = tl.exp(qk * softmax_scale - lse_i[:, None])
+        p = tl.where(valid, p, 0.0)
+
+        dv_block = tl.dot(p.to(do.dtype).T, do)
+        tl.atomic_add(dv_page_ptr + kv_offs, dv_block, mask=kv_mask, sem="relaxed")
+
+        dp = tl.dot(do, v.T)
+        ds = (p * (dp - Di[:, None]) * softmax_scale).to(q.dtype)
+
+        dk_block = tl.dot(ds.T, q)
+        tl.atomic_add(dk_page_ptr + kv_offs, dk_block, mask=kv_mask, sem="relaxed")
+
+        dq_block += tl.dot(ds, k)
+
+    if EVEN_M:
+        tl.store(dq_ptrs, dq_block)
+    else:
+        tl.store(dq_ptrs, dq_block, mask=mask_m[:, None])
+
+
 def _flash_attn_forward(
         q: torch.Tensor,
         page_table: torch.Tensor,
@@ -274,7 +469,7 @@ def _flash_attn_forward(
     batch, seqlen_q, nheads, d = q.shape
     seqlen_k = num_kv
     
-    assert d <= 128
+    validate_flash_paged_head_dim(d)
     assert q.dtype in [torch.float16, torch.bfloat16]
     assert q.is_cuda
 
@@ -313,6 +508,63 @@ def _flash_attn_forward(
     return o, lse, softmax_scale
 
 
+def _flash_attn_indexed_forward(
+        q: torch.Tensor,
+        page_table: torch.Tensor,
+        page_indices: torch.Tensor,
+        page_size: int,
+        total_num_kv: int,
+        num_kv_heads: int,
+        kv_head_dim: int,
+        q_start_idx: int,
+        softmax_scale=None):
+
+    BLOCK_M = page_size
+    BLOCK_N = page_size
+
+    batch, seqlen_q, nheads, d = q.shape
+
+    validate_flash_paged_head_dim(d)
+    assert q.dtype in [torch.float16, torch.bfloat16]
+    assert q.is_cuda
+    assert page_indices.is_cuda
+    assert page_indices.ndim == 1
+
+    softmax_scale = softmax_scale or 1.0 / math.sqrt(d)
+
+    seqlen_q_rounded = math.ceil(seqlen_q / BLOCK_M) * BLOCK_M
+    lse = torch.empty((batch, nheads, seqlen_q_rounded), device=q.device, dtype=torch.float32)
+    o = torch.empty_like(q)
+
+    BLOCK_HEADDIM = max(triton.next_power_of_2(d), 16)
+    GROUP_SIZE = nheads // num_kv_heads
+
+    grid = (triton.cdiv(seqlen_q, BLOCK_M), batch * nheads)
+    num_warps = 4 if d <= 64 else 8
+
+    stride_kvb = page_size * num_kv_heads * kv_head_dim
+    stride_kvn = num_kv_heads * kv_head_dim
+    stride_kvh = kv_head_dim
+
+    _fwd_indexed_kernel[grid](
+        q, page_table, page_indices,
+        o, lse,
+        softmax_scale,
+        q.stride(0), q.stride(2), q.stride(1),
+        o.stride(0), o.stride(2), o.stride(1),
+        stride_kvb, stride_kvh, stride_kvn,
+        nheads, seqlen_q, q_start_idx, d,
+        seqlen_q_rounded, total_num_kv, page_indices.numel(), num_kv_heads,
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
+        BLOCK_HEADDIM=BLOCK_HEADDIM,
+        EVEN_M=(seqlen_q % BLOCK_M == 0),
+        GROUP_SIZE=GROUP_SIZE,
+        num_warps=num_warps,
+        num_stages=1)
+
+    return o, lse[:, :, :seqlen_q], softmax_scale
+
+
 def _flash_attn_backward(
         o: torch.Tensor,
         do: torch.Tensor,
@@ -334,6 +586,7 @@ def _flash_attn_backward(
     BLOCK_N = page_size
 
     batch, seqlen_q, nheads, d = q.shape
+    validate_flash_paged_head_dim(d)
     seqlen_k = num_kv
     seqlen_q_rounded = math.ceil(seqlen_q / BLOCK_M) * BLOCK_M
     
@@ -369,6 +622,76 @@ def _flash_attn_backward(
         dq.stride(0), dq.stride(2), dq.stride(1),
         nheads, seqlen_q, q_start_idx, d,
         seqlen_q_rounded, seqlen_k, num_kv_heads,
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
+        BLOCK_HEADDIM=BLOCK_HEADDIM,
+        EVEN_M=(seqlen_q % BLOCK_M == 0),
+        GROUP_SIZE=GROUP_SIZE,
+        FP32_ATOMIC_ADD=(not IS_BF16_ATOM_ADD_SUPPORTED),
+        num_warps=num_warps,
+        num_stages=1)
+
+
+def _flash_attn_indexed_backward(
+        o: torch.Tensor,
+        do: torch.Tensor,
+        q: torch.Tensor,
+        dq: torch.Tensor,
+        page_table: torch.Tensor,
+        page_indices: torch.Tensor,
+        page_size: int,
+        total_num_kv: int,
+        num_kv_heads: int,
+        kv_head_dim: int,
+        q_start_idx: int,
+        lse: torch.Tensor,
+        softmax_scale: float):
+    if do.stride(-1) != 1:
+        do = do.contiguous()
+    if page_indices.numel() == 0:
+        return
+
+    BLOCK_M = page_size
+    BLOCK_N = page_size
+
+    batch, seqlen_q, nheads, d = q.shape
+    validate_flash_paged_head_dim(d)
+    seqlen_q_rounded = math.ceil(seqlen_q / BLOCK_M) * BLOCK_M
+    if lse.shape[-1] != seqlen_q_rounded:
+        padded = torch.empty(
+            (batch, nheads, seqlen_q_rounded),
+            device=lse.device, dtype=lse.dtype)
+        padded[:, :, :seqlen_q] = lse
+        lse = padded
+
+    delta = torch.empty_like(lse)
+    BLOCK_HEADDIM = max(triton.next_power_of_2(d), 16)
+    GROUP_SIZE = nheads // num_kv_heads
+
+    grid_preprocess = (triton.cdiv(seqlen_q, BLOCK_M), batch * nheads)
+    _bwd_preprocess_do_o_dot[grid_preprocess](
+        o, do, delta,
+        o.stride(0), o.stride(2), o.stride(1),
+        do.stride(0), do.stride(2), do.stride(1),
+        nheads, seqlen_q, seqlen_q_rounded,
+        EVEN_M=(seqlen_q % BLOCK_M == 0),
+        BLOCK_M=BLOCK_M, BLOCK_HEADDIM=BLOCK_HEADDIM)
+
+    num_warps = 4 if kv_head_dim <= 64 else 8
+    stride_kvb = page_size * num_kv_heads * kv_head_dim
+    stride_kvn = num_kv_heads * kv_head_dim
+    stride_kvh = kv_head_dim
+
+    grid_bwd = (triton.cdiv(seqlen_q, BLOCK_M), batch * nheads)
+    _bwd_indexed_kernel[grid_bwd](
+        q, do, dq, page_table, page_indices,
+        lse, delta,
+        softmax_scale,
+        q.stride(0), q.stride(2), q.stride(1),
+        stride_kvb, stride_kvh, stride_kvn,
+        do.stride(0), do.stride(2), do.stride(1),
+        dq.stride(0), dq.stride(2), dq.stride(1),
+        nheads, seqlen_q, q_start_idx, d,
+        seqlen_q_rounded, total_num_kv, page_indices.numel(), num_kv_heads,
         BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
         BLOCK_HEADDIM=BLOCK_HEADDIM,
         EVEN_M=(seqlen_q % BLOCK_M == 0),
@@ -428,3 +751,130 @@ class FlashPagedAttn(torch.autograd.Function):
 
 
 flash_paged_attn_func = FlashPagedAttn.apply
+
+
+class DistributedFlashPagedAttn(torch.autograd.Function):
+    @staticmethod
+    def forward(
+            ctx, q, k, v, manager, group=None,
+            reduce_dtype=torch.float32, merge_backend="allreduce"):
+        import torch.distributed as dist
+
+        q = q if q.stride(-1) == 1 else q.contiguous()
+        try:
+            page_indices = manager.page_indices_tensor(
+                q.device, for_autograd=True)
+        except TypeError:
+            page_indices = manager.page_indices_tensor(q.device)
+            if hasattr(torch, "is_inference") and torch.is_inference(page_indices):
+                page_indices = page_indices.clone()
+        if page_indices.numel() == 0:
+            batch, seqlen_q, nheads, _ = q.shape
+            local_out = torch.zeros_like(q)
+            local_lse = torch.full(
+                (batch, nheads, seqlen_q),
+                float("-inf"),
+                dtype=torch.float32,
+                device=q.device)
+            softmax_scale = 1.0 / math.sqrt(q.shape[-1])
+        else:
+            local_out, local_lse, softmax_scale = _flash_attn_indexed_forward(
+                q,
+                manager.page_table,
+                page_indices,
+                manager.page_size,
+                manager.num_kv,
+                manager.num_kv_heads,
+                manager.head_dim,
+                manager.num_kv - q.shape[1],
+                softmax_scale=None)
+        out, global_lse = distributed_lse_merge(
+            local_out, local_lse, group=group,
+            backend=merge_backend, reduce_dtype=reduce_dtype,
+            fallback_to_local=False)
+        ctx.save_for_backward(q, out, global_lse, page_indices)
+        ctx.manager = manager
+        ctx.group = group
+        ctx.softmax_scale = softmax_scale
+        return out
+
+    @staticmethod
+    def backward(ctx, do):
+        import torch.distributed as dist
+
+        q, out, global_lse, page_indices = ctx.saved_tensors
+        dq = torch.zeros_like(q)
+        if page_indices.numel() > 0:
+            _flash_attn_indexed_backward(
+                out, do, q, dq,
+                ctx.manager.page_table,
+                page_indices,
+                ctx.manager.page_size,
+                ctx.manager.num_kv,
+                ctx.manager.num_kv_heads,
+                ctx.manager.head_dim,
+                ctx.manager.num_kv - q.shape[1],
+                global_lse,
+                ctx.softmax_scale)
+        dist.all_reduce(dq, op=dist.ReduceOp.SUM, group=ctx.group)
+        dk, dv = ctx.manager.grad
+        return dq, dk, dv, None, None, None, None
+
+
+flash_paged_attn_distributed_func = DistributedFlashPagedAttn.apply
+
+
+def flash_paged_attn_forward_with_lse(
+        q: torch.Tensor,
+        manager,
+        page_indices=None,
+        page_table=None,
+        total_num_kv=None,
+        q_start_idx=None):
+    """Forward-only paged attention that exposes local LSE.
+
+    If page_indices is None this runs the existing dense paged kernel over the
+    full manager. Otherwise it attends only to the listed global page indices
+    while preserving their original token positions for the causal mask.
+    """
+    q = q if q.stride(-1) == 1 else q.contiguous()
+    if page_indices is None:
+        o, lse, _ = _flash_attn_forward(
+            q,
+            manager.page_table,
+            manager.page_size,
+            manager.num_kv,
+            manager.num_kv_heads,
+            manager.head_dim,
+            manager.num_kv - q.shape[1],
+            softmax_scale=None)
+        return o, lse[:, :, :q.shape[1]]
+
+    if not torch.is_tensor(page_indices):
+        page_indices = torch.tensor(
+            page_indices, dtype=torch.int64, device=q.device)
+    else:
+        page_indices = page_indices.to(device=q.device, dtype=torch.int64)
+    if page_indices.numel() == 0:
+        batch, seqlen_q, nheads, _ = q.shape
+        return (
+            torch.zeros_like(q),
+            torch.full(
+                (batch, nheads, seqlen_q),
+                float("-inf"),
+                dtype=torch.float32,
+                device=q.device))
+    if page_table is None:
+        page_table = manager.page_table.index_select(0, page_indices)
+    o, lse, _ = _flash_attn_indexed_forward(
+        q,
+        page_table,
+        page_indices,
+        manager.page_size,
+        manager.num_kv if total_num_kv is None else total_num_kv,
+        manager.num_kv_heads,
+        manager.head_dim,
+        ((manager.num_kv if total_num_kv is None else total_num_kv)
+         - q.shape[1]) if q_start_idx is None else q_start_idx,
+        softmax_scale=None)
+    return o, lse

--- a/chunkoptim/ops/ring_context_parallel.py
+++ b/chunkoptim/ops/ring_context_parallel.py
@@ -1,0 +1,133 @@
+"""Reference exact ring context-parallel attention primitives.
+
+This module is intentionally small and PyTorch-first. It provides the exact
+online-softmax state update needed by ring/USP style context parallelism:
+query blocks stay local, KV blocks rotate across ranks, and every rank merges
+each visited KV block into its local output without materializing full scores.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+import torch
+
+
+@dataclass
+class OnlineAttentionState:
+    max_score: torch.Tensor
+    denominator: torch.Tensor
+    numerator: torch.Tensor
+
+
+def ring_kv_owner(*, rank: int, step: int, world_size: int) -> int:
+    """Return the original KV owner seen by rank after `step` ring receives."""
+    if world_size < 1:
+        raise ValueError("world_size must be >= 1")
+    return (rank - step) % world_size
+
+
+def init_online_attention_state(
+        *,
+        batch_size: int,
+        q_len: int,
+        num_heads: int,
+        head_dim: int,
+        device,
+        dtype: torch.dtype = torch.float32) -> OnlineAttentionState:
+    """Create empty online softmax accumulators."""
+    max_score = torch.full(
+        (batch_size, num_heads, q_len), -float("inf"),
+        device=device, dtype=torch.float32)
+    denominator = torch.zeros_like(max_score)
+    numerator = torch.zeros(
+        batch_size, q_len, num_heads, head_dim,
+        device=device, dtype=dtype)
+    return OnlineAttentionState(max_score, denominator, numerator)
+
+
+def _expand_gqa_kv(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if query.shape[2] == key.shape[2]:
+        return key, value
+    if query.shape[2] % key.shape[2] != 0:
+        raise ValueError("query heads must be divisible by KV heads")
+    repeats = query.shape[2] // key.shape[2]
+    return (
+        key.repeat_interleave(repeats, dim=2),
+        value.repeat_interleave(repeats, dim=2),
+    )
+
+
+def online_attention_update(
+        state: OnlineAttentionState,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        *,
+        q_start: int,
+        k_start: int,
+        causal: bool = True) -> OnlineAttentionState:
+    """Merge one KV block into an online exact attention state.
+
+    Shapes:
+        query: [batch, q_len, heads, dim]
+        key/value: [batch, kv_len, kv_heads, dim]
+    """
+    if key.shape != value.shape:
+        raise ValueError("key and value must have matching shape")
+    key, value = _expand_gqa_kv(query, key, value)
+    if query.shape[0] != key.shape[0]:
+        raise ValueError("query and key must share batch size")
+    if query.shape[2:] != key.shape[2:]:
+        raise ValueError("query/key head and dim shapes must match after GQA")
+
+    scores = torch.einsum("bqhd,bkhd->bhqk", query.float(), key.float())
+    scores = scores / math.sqrt(query.shape[-1])
+    if causal:
+        q_pos = torch.arange(
+            q_start, q_start + query.shape[1], device=query.device)
+        k_pos = torch.arange(
+            k_start, k_start + key.shape[1], device=query.device)
+        causal_mask = k_pos.view(1, 1, 1, -1) > q_pos.view(1, 1, -1, 1)
+        scores = scores.masked_fill(causal_mask, -float("inf"))
+
+    block_max = scores.max(dim=-1).values
+    new_max = torch.maximum(state.max_score, block_max)
+    old_scale = torch.exp(state.max_score - new_max)
+    old_scale = torch.where(
+        torch.isneginf(state.max_score), torch.zeros_like(old_scale), old_scale)
+    block_exp = torch.exp(scores - new_max.unsqueeze(-1))
+    block_exp = torch.where(
+        torch.isfinite(scores), block_exp, torch.zeros_like(block_exp))
+    block_denominator = block_exp.sum(dim=-1)
+    block_numerator = torch.einsum("bhqk,bkhd->bqhd", block_exp, value.float())
+
+    old_numerator = (
+        state.numerator.float()
+        * old_scale.permute(0, 2, 1).unsqueeze(-1))
+    numerator = old_numerator + block_numerator
+    denominator = state.denominator * old_scale + block_denominator
+    return OnlineAttentionState(
+        max_score=new_max,
+        denominator=denominator,
+        numerator=numerator.to(state.numerator.dtype))
+
+
+def finalize_online_attention(
+        state: OnlineAttentionState,
+        *,
+        output_dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
+    """Normalize online attention accumulators into output and global LSE."""
+    denom = state.denominator.clamp_min(1e-30)
+    output = state.numerator.float() / denom.permute(0, 2, 1).unsqueeze(-1)
+    empty = state.denominator == 0
+    output = torch.where(
+        empty.permute(0, 2, 1).unsqueeze(-1),
+        torch.zeros_like(output),
+        output)
+    lse = state.max_score + torch.log(denom)
+    lse = torch.where(empty, torch.full_like(lse, -float("inf")), lse)
+    return output.to(output_dtype), lse

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-from setuptools import setup
+from setuptools import find_namespace_packages, setup
 
 setup(
     name='chunkoptim',
     version='2.0',
-    packages=['chunkoptim'],
+    packages=find_namespace_packages(include=["chunkoptim", "chunkoptim.*"]),
     install_requires=[]
 )

--- a/test_efficiency/test.py
+++ b/test_efficiency/test.py
@@ -268,7 +268,11 @@ def blockwise_tensor_parallel_sparse(model, batch, grad_ckpt, block_size, page_s
         kv_cache.post_process()
 
 
-def blockwise_tensor_parallel(model, batch, grad_ckpt, block_size, page_size, cpu_offload):
+def blockwise_tensor_parallel(
+        model, batch, grad_ckpt, block_size, page_size, cpu_offload,
+        attention_backend="paged", attention_merge_backend="allreduce",
+        attention_reduce_dtype="float32", attention_query_block_size=128,
+        attention_kv_block_size=128, attention_fallback_to_local=True):
     my_chunkize = partial(chunkize, dim=-1, chunk_size=block_size)
     input_ids = list(my_chunkize(batch['input_ids']))
     labels = list(my_chunkize(batch['labels']))
@@ -281,7 +285,15 @@ def blockwise_tensor_parallel(model, batch, grad_ckpt, block_size, page_size, cp
             batch_size=1,
             page_size=page_size,
             num_heads=model.model.config.num_key_value_heads // dist.get_world_size(),
-            cpu_offload=cpu_offload)
+            cpu_offload=cpu_offload,
+            attention_conf={
+                "backend": attention_backend,
+                "merge_backend": attention_merge_backend,
+                "reduce_dtype": attention_reduce_dtype,
+                "fallback_to_local": attention_fallback_to_local,
+                "query_block_size": attention_query_block_size,
+                "kv_block_size": attention_kv_block_size,
+            })
     dist.barrier()
     if dist.get_rank() != 0:
         kv_cache = KVCache(
@@ -289,7 +301,15 @@ def blockwise_tensor_parallel(model, batch, grad_ckpt, block_size, page_size, cp
             batch_size=1,
             page_size=page_size,
             num_heads=model.model.config.num_key_value_heads // dist.get_world_size(),
-            cpu_offload=cpu_offload)
+            cpu_offload=cpu_offload,
+            attention_conf={
+                "backend": attention_backend,
+                "merge_backend": attention_merge_backend,
+                "reduce_dtype": attention_reduce_dtype,
+                "fallback_to_local": attention_fallback_to_local,
+                "query_block_size": attention_query_block_size,
+                "kv_block_size": attention_kv_block_size,
+            })
     dist.barrier()
 
     with torch.no_grad():

--- a/test_ops/test_blockwise_attention.py
+++ b/test_ops/test_blockwise_attention.py
@@ -1,0 +1,188 @@
+import torch
+
+from chunkoptim.modifiers.blockwise_attention import (
+    resolve_attention_config,
+    run_blockwise_attention,
+)
+from chunkoptim.cache.kv_cache import KVCache
+
+
+class DummyManager:
+    def __init__(self):
+        self.called = None
+
+
+def test_resolve_attention_config_defaults_to_paged():
+    manager = DummyManager()
+
+    config = resolve_attention_config(manager)
+
+    assert config["backend"] == "paged"
+    assert config["merge_backend"] == "allreduce"
+    assert config["reduce_dtype"] == torch.float32
+
+
+def test_resolve_attention_config_accepts_manager_config_aliases():
+    manager = DummyManager()
+    manager.attention_conf = {
+        "backend": "distributed-paged",
+        "merge_backend": "allgather_ref",
+        "reduce_dtype": "bf16",
+    }
+
+    config = resolve_attention_config(manager)
+
+    assert config["backend"] == "distributed_paged"
+    assert config["merge_backend"] == "allgather_ref"
+    assert config["reduce_dtype"] == torch.bfloat16
+
+
+def test_run_blockwise_attention_dispatches_paged_backend(monkeypatch):
+    calls = []
+
+    def fake_paged(q, k, v, manager):
+        calls.append(("paged", q, k, v, manager))
+        return q + 1
+
+    monkeypatch.setattr(
+        "chunkoptim.modifiers.blockwise_attention.flash_paged_attn_func",
+        fake_paged)
+    q = torch.zeros(1, 2, 1, 4)
+    k = torch.zeros(1, 2, 1, 4)
+    v = torch.zeros(1, 2, 1, 4)
+    manager = DummyManager()
+
+    out = run_blockwise_attention(q, k, v, manager)
+
+    assert torch.equal(out, torch.ones_like(q))
+    assert calls == [("paged", q, k, v, manager)]
+
+
+def test_resolve_attention_config_parses_string_booleans():
+    manager = DummyManager()
+    manager.attention_conf = {
+        "backend": "distributed_paged",
+        "fallback_to_local": "false",
+    }
+
+    config = resolve_attention_config(manager)
+
+    assert config["fallback_to_local"] is False
+
+
+def test_run_blockwise_attention_dispatches_distributed_backend(monkeypatch):
+    calls = []
+
+    def fake_distributed(
+            q, k, v, manager, group, reduce_dtype, merge_backend,
+            fallback_to_local):
+        calls.append((
+            q, k, v, manager, group, reduce_dtype, merge_backend,
+            fallback_to_local))
+        return q + 2
+
+    monkeypatch.setattr(
+        "chunkoptim.modifiers.blockwise_attention.flash_paged_attn_distributed_func",
+        fake_distributed)
+    q = torch.zeros(1, 2, 1, 4)
+    k = torch.zeros(1, 2, 1, 4)
+    v = torch.zeros(1, 2, 1, 4)
+    manager = DummyManager()
+    manager.attention_conf = {
+        "backend": "distributed_paged",
+        "merge_backend": "allgather_ref",
+        "reduce_dtype": torch.bfloat16,
+    }
+
+    out = run_blockwise_attention(q, k, v, manager)
+
+    assert torch.equal(out, torch.full_like(q, 2))
+    assert calls == [(
+        q, k, v, manager, None, torch.bfloat16, "allgather_ref", True)]
+
+
+def test_run_blockwise_attention_passes_distributed_fallback(monkeypatch):
+    calls = []
+
+    def fake_distributed(
+            q, k, v, manager, group, reduce_dtype, merge_backend,
+            fallback_to_local):
+        calls.append(fallback_to_local)
+        return q + 4
+
+    monkeypatch.setattr(
+        "chunkoptim.modifiers.blockwise_attention.flash_paged_attn_distributed_func",
+        fake_distributed)
+    q = torch.zeros(1, 2, 1, 4)
+    k = torch.zeros(1, 2, 1, 4)
+    v = torch.zeros(1, 2, 1, 4)
+    manager = DummyManager()
+    manager.attention_conf = {"backend": "distributed_paged"}
+
+    out = run_blockwise_attention(q, k, v, manager)
+
+    assert torch.equal(out, torch.full_like(q, 4))
+    assert calls == [True]
+
+
+def test_run_blockwise_attention_dispatches_rectangular_reference(monkeypatch):
+    calls = []
+
+    def fake_rectangular(q, k, v, manager, query_block_size, kv_block_size):
+        calls.append((q, k, v, manager, query_block_size, kv_block_size))
+        return q + 3
+
+    monkeypatch.setattr(
+        "chunkoptim.modifiers.blockwise_attention.paged_rectangular_attention",
+        fake_rectangular)
+    q = torch.zeros(1, 2, 1, 4)
+    k = torch.zeros(1, 2, 1, 4)
+    v = torch.zeros(1, 2, 1, 4)
+    manager = DummyManager()
+    manager.attention_conf = {
+        "backend": "rectangular",
+        "query_block_size": 4,
+        "kv_block_size": 8,
+    }
+
+    out = run_blockwise_attention(q, k, v, manager)
+
+    assert torch.equal(out, torch.full_like(q, 3))
+    assert calls == [(q, k, v, manager, 4, 8)]
+
+
+def test_run_blockwise_attention_rejects_unknown_backend():
+    q = torch.zeros(1, 2, 1, 4)
+    k = torch.zeros(1, 2, 1, 4)
+    v = torch.zeros(1, 2, 1, 4)
+    manager = DummyManager()
+    manager.attention_conf = {"backend": "bad"}
+
+    try:
+        run_blockwise_attention(q, k, v, manager)
+    except ValueError as exc:
+        assert "unsupported blockwise attention backend" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_kv_cache_attaches_attention_config_to_managers():
+    cache = KVCache(
+        num_layers=2,
+        batch_size=1,
+        page_size=2,
+        num_heads=1,
+        head_dim=4,
+        cpu_offload=None,
+        local_rank=0,
+        attention_conf={
+            "backend": "distributed_paged",
+            "merge_backend": "allgather_ref",
+        },
+    )
+
+    assert cache.attention_conf["backend"] == "distributed_paged"
+    assert [m.attention_conf for m in cache.managers] == [
+        cache.attention_conf,
+        cache.attention_conf,
+    ]

--- a/test_ops/test_distributed_attention.py
+++ b/test_ops/test_distributed_attention.py
@@ -89,6 +89,20 @@ def test_distributed_lse_merge_single_rank_uses_same_math():
     torch.testing.assert_close(global_lse, local_lse)
 
 
+def test_distributed_lse_merge_can_fallback_to_local_when_dist_uninitialized():
+    local_output = torch.randn(1, 3, 2, 4, dtype=torch.bfloat16)
+    local_lse = torch.randn(1, 2, 3, dtype=torch.float32)
+
+    combined, global_lse = distributed_lse_merge(
+        local_output, local_lse,
+        backend="allreduce",
+        reduce_dtype=torch.float32,
+        fallback_to_local=True)
+
+    torch.testing.assert_close(combined.float(), local_output.float())
+    torch.testing.assert_close(global_lse, local_lse)
+
+
 def test_distributed_lse_merge_rejects_unknown_backend():
     local_output = torch.randn(1, 1, 1, 1)
     local_lse = torch.randn(1, 1, 1)

--- a/test_ops/test_distributed_attention.py
+++ b/test_ops/test_distributed_attention.py
@@ -1,0 +1,157 @@
+import torch
+import torch.multiprocessing as mp
+
+from chunkoptim.ops.distributed_attention import (
+    combine_attention_outputs_from_lse,
+    distributed_lse_merge,
+    sanitize_empty_attention_output,
+)
+
+
+def test_lse_merge_matches_manual_weighted_sum():
+    local_outputs = torch.tensor(
+        [
+            [[[[1.0, 2.0], [10.0, 20.0]],
+              [[3.0, 4.0], [30.0, 40.0]]]],
+            [[[[5.0, 6.0], [50.0, 60.0]],
+              [[7.0, 8.0], [70.0, 80.0]]]],
+        ],
+        dtype=torch.bfloat16,
+    )
+    local_lses = torch.tensor(
+        [
+            [[[0.0, 1.0], [2.0, 3.0]]],
+            [[[4.0, 5.0], [6.0, 7.0]]],
+        ],
+        dtype=torch.float32,
+    )
+
+    combined, global_lse = combine_attention_outputs_from_lse(
+        local_outputs, local_lses)
+
+    expected_lse = torch.logsumexp(local_lses, dim=0)
+    weights = torch.exp(local_lses - expected_lse.unsqueeze(0))
+    expected = (
+        local_outputs.float()
+        * weights.permute(0, 1, 3, 2).unsqueeze(-1)
+    ).sum(dim=0)
+    torch.testing.assert_close(global_lse, expected_lse)
+    torch.testing.assert_close(combined.float(), expected, rtol=4e-3, atol=4e-3)
+
+
+def test_lse_merge_ignores_empty_local_shards():
+    local_outputs = torch.tensor(
+        [
+            [[[[float("nan"), float("nan")], [10.0, 20.0]]]],
+            [[[[5.0, 6.0], [50.0, 60.0]]]],
+        ],
+        dtype=torch.float32,
+    )
+    local_lses = torch.tensor(
+        [
+            [[[-float("inf")], [2.0]]],
+            [[[4.0], [6.0]]],
+        ],
+        dtype=torch.float32,
+    )
+
+    combined, global_lse = combine_attention_outputs_from_lse(
+        local_outputs, local_lses)
+
+    expected_lse = torch.logsumexp(local_lses, dim=0)
+    torch.testing.assert_close(global_lse, expected_lse)
+    torch.testing.assert_close(combined[0, 0, 0], torch.tensor([5.0, 6.0]))
+    assert torch.isfinite(combined).all()
+
+
+def test_sanitize_empty_attention_output_supports_stacked_and_unstacked():
+    output = torch.ones(1, 2, 3, 4)
+    lse = torch.tensor([[[0.0, -float("inf")],
+                         [-float("inf"), 1.0],
+                         [2.0, 3.0]]])
+    cleaned = sanitize_empty_attention_output(output, lse)
+    assert cleaned[0, 1, 0].abs().sum().item() == 0.0
+    assert cleaned[0, 0, 1].abs().sum().item() == 0.0
+    assert cleaned[0, 0, 0].abs().sum().item() > 0.0
+
+    stacked = sanitize_empty_attention_output(output.unsqueeze(0), lse.unsqueeze(0))
+    torch.testing.assert_close(stacked[0], cleaned)
+
+
+def test_distributed_lse_merge_single_rank_uses_same_math():
+    local_output = torch.randn(1, 3, 2, 4, dtype=torch.bfloat16)
+    local_lse = torch.randn(1, 2, 3, dtype=torch.float32)
+
+    combined, global_lse = distributed_lse_merge(
+        local_output, local_lse, backend="allreduce", reduce_dtype=torch.float32)
+
+    torch.testing.assert_close(combined.float(), local_output.float())
+    torch.testing.assert_close(global_lse, local_lse)
+
+
+def test_distributed_lse_merge_rejects_unknown_backend():
+    local_output = torch.randn(1, 1, 1, 1)
+    local_lse = torch.randn(1, 1, 1)
+    try:
+        distributed_lse_merge(local_output, local_lse, backend="not-a-backend")
+    except ValueError as exc:
+        assert "unsupported distributed attention merge backend" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def _distributed_lse_merge_worker(rank, world_size, init_file, queue):
+    import torch.distributed as dist
+
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size)
+    try:
+        local_output = torch.tensor(
+            [[[[1.0 + rank, 2.0 + rank],
+               [3.0 + rank, 4.0 + rank]]]],
+            dtype=torch.float32)
+        local_lse = torch.tensor(
+            [[[float(rank), float(rank + 1)]]],
+            dtype=torch.float32)
+        combined, global_lse = distributed_lse_merge(
+            local_output, local_lse, backend="allreduce")
+
+        stacked_outputs = torch.stack([
+            torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]], dtype=torch.float32),
+            torch.tensor([[[[2.0, 3.0], [4.0, 5.0]]]], dtype=torch.float32),
+        ])
+        stacked_lses = torch.stack([
+            torch.tensor([[[0.0, 1.0]]], dtype=torch.float32),
+            torch.tensor([[[1.0, 2.0]]], dtype=torch.float32),
+        ])
+        expected, expected_lse = combine_attention_outputs_from_lse(
+            stacked_outputs, stacked_lses)
+        torch.testing.assert_close(combined, expected, rtol=1e-6, atol=1e-6)
+        torch.testing.assert_close(global_lse, expected_lse, rtol=1e-6, atol=1e-6)
+        queue.put("ok")
+    finally:
+        dist.destroy_process_group()
+
+
+def test_distributed_lse_merge_allreduce_matches_reference_across_ranks(tmp_path):
+    ctx = mp.get_context("spawn")
+    queue = ctx.Queue()
+    init_file = tmp_path / "dist_init"
+    processes = [
+        ctx.Process(
+            target=_distributed_lse_merge_worker,
+            args=(rank, 2, str(init_file), queue))
+        for rank in range(2)
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=30)
+
+    exitcodes = [process.exitcode for process in processes]
+    assert exitcodes == [0, 0]
+    assert [queue.get(timeout=5) for _ in processes] == ["ok", "ok"]

--- a/test_ops/test_exact_attn_bench.py
+++ b/test_ops/test_exact_attn_bench.py
@@ -1,0 +1,51 @@
+import math
+
+import torch
+
+from chunkoptim.ops.exact_attn_bench import run_rectangular_attention_benchmark
+
+
+def test_rectangular_attention_benchmark_reports_timing_and_error():
+    result = run_rectangular_attention_benchmark(
+        batch_size=1,
+        q_len=3,
+        kv_len=5,
+        num_heads=2,
+        num_kv_heads=1,
+        head_dim=4,
+        query_block_size=2,
+        kv_block_size=2,
+        q_start=2,
+        device="cpu",
+        dtype=torch.float32,
+        seed=123,
+        warmup=0,
+        repeat=1,
+        check_dense=True,
+    )
+
+    assert result["backend"] == "rectangular_exact"
+    assert result["device"] == "cpu"
+    assert result["dtype"] == "torch.float32"
+    assert result["shape"] == {
+        "batch_size": 1,
+        "q_len": 3,
+        "kv_len": 5,
+        "num_heads": 2,
+        "num_kv_heads": 1,
+        "head_dim": 4,
+    }
+    assert result["tiles"] == {
+        "query_block_size": 2,
+        "kv_block_size": 2,
+        "query_blocks": 2,
+        "kv_blocks": 3,
+        "tile_count": 6,
+    }
+    assert result["score_cells"] == 1 * 2 * 3 * 5
+    assert result["timing_s"]["rectangular_forward_avg"] >= 0.0
+    assert result["timing_s"]["materialize_avg"] >= 0.0
+    assert result["dense_check"]["enabled"] is True
+    assert result["dense_check"]["max_abs_error"] < 1e-5
+    assert result["dense_check"]["max_rel_error"] < 1e-5
+    assert math.isfinite(result["dense_check"]["dense_forward_s"])

--- a/test_ops/test_exact_streaming_attn.py
+++ b/test_ops/test_exact_streaming_attn.py
@@ -1,0 +1,214 @@
+import math
+
+import torch
+
+from chunkoptim.cache.kv_cache import SimpleCacheManager
+from chunkoptim.ops.cp_transport import (
+    rectangular_kv_schedule,
+    ring_kv_schedule,
+    usp_kv_schedule,
+)
+from chunkoptim.ops.exact_streaming_attn import (
+    materialize_paged_kv,
+    paged_rectangular_attention,
+    rectangular_streaming_attention,
+)
+
+
+def dense_attention_reference(query, key, value, *, causal=True,
+                              q_start=0, kv_start=0):
+    num_heads = query.shape[2]
+    num_kv_heads = key.shape[2]
+    if num_heads % num_kv_heads != 0:
+        raise ValueError("query heads must be divisible by kv heads")
+    groups = num_heads // num_kv_heads
+    if groups != 1:
+        key = key.repeat_interleave(groups, dim=2)
+        value = value.repeat_interleave(groups, dim=2)
+
+    scores = torch.einsum("bqhd,bkhd->bhqk", query.float(), key.float())
+    scores = scores / math.sqrt(query.shape[-1])
+    if causal:
+        q_pos = torch.arange(
+            q_start, q_start + query.shape[1], device=query.device)
+        kv_pos = torch.arange(
+            kv_start, kv_start + key.shape[1], device=query.device)
+        allowed = kv_pos.unsqueeze(0) <= q_pos.unsqueeze(1)
+        scores = scores.masked_fill(
+            ~allowed.unsqueeze(0).unsqueeze(0), -float("inf"))
+
+    valid = torch.isfinite(scores).any(dim=-1, keepdim=True)
+    probs = torch.softmax(scores, dim=-1)
+    probs = torch.where(valid, probs, torch.zeros_like(probs))
+    out = torch.einsum("bhqk,bkhd->bqhd", probs, value.float())
+    return out.to(query.dtype)
+
+
+def test_rectangular_streaming_attention_matches_dense_causal_gqa():
+    torch.manual_seed(0)
+    query = torch.randn(2, 5, 4, 8)
+    key = torch.randn(2, 7, 2, 8)
+    value = torch.randn(2, 7, 2, 8)
+
+    out, lse = rectangular_streaming_attention(
+        query, key, value,
+        query_block_size=2,
+        kv_block_size=3,
+        causal=True,
+        q_start=3,
+        kv_start=0,
+        return_lse=True,
+    )
+
+    ref = dense_attention_reference(
+        query, key, value, causal=True, q_start=3, kv_start=0)
+    assert out.shape == query.shape
+    assert lse.shape == (2, 4, 5)
+    assert torch.allclose(out, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_rectangular_streaming_attention_handles_all_masked_rows():
+    query = torch.randn(1, 2, 2, 4)
+    key = torch.randn(1, 3, 2, 4)
+    value = torch.randn(1, 3, 2, 4)
+
+    out, lse = rectangular_streaming_attention(
+        query, key, value,
+        query_block_size=1,
+        kv_block_size=2,
+        causal=True,
+        q_start=0,
+        kv_start=5,
+        return_lse=True,
+    )
+
+    assert torch.equal(out, torch.zeros_like(out))
+    assert torch.isneginf(lse).all()
+
+
+def test_rectangular_streaming_attention_backward_matches_dense():
+    torch.manual_seed(1)
+    query = torch.randn(1, 4, 2, 5, requires_grad=True)
+    key = torch.randn(1, 6, 2, 5, requires_grad=True)
+    value = torch.randn(1, 6, 2, 5, requires_grad=True)
+    query_ref = query.detach().clone().requires_grad_(True)
+    key_ref = key.detach().clone().requires_grad_(True)
+    value_ref = value.detach().clone().requires_grad_(True)
+
+    out = rectangular_streaming_attention(
+        query, key, value,
+        query_block_size=3,
+        kv_block_size=4,
+        causal=True,
+        q_start=2,
+        kv_start=0,
+    )
+    ref = dense_attention_reference(
+        query_ref, key_ref, value_ref, causal=True, q_start=2, kv_start=0)
+
+    out.square().sum().backward()
+    ref.square().sum().backward()
+
+    assert torch.allclose(out, ref, atol=1e-5, rtol=1e-5)
+    assert torch.allclose(query.grad, query_ref.grad, atol=2e-5, rtol=2e-5)
+    assert torch.allclose(key.grad, key_ref.grad, atol=2e-5, rtol=2e-5)
+    assert torch.allclose(value.grad, value_ref.grad, atol=2e-5, rtol=2e-5)
+
+
+def test_rectangular_kv_schedule_covers_non_divisible_range_once():
+    blocks = rectangular_kv_schedule(num_kv=10, kv_block_size=4)
+
+    assert [(b.start, b.end, b.backend, b.owner_rank, b.hop) for b in blocks] == [
+        (0, 4, "rectangular", None, 0),
+        (4, 8, "rectangular", None, 0),
+        (8, 10, "rectangular", None, 0),
+    ]
+
+
+def test_ring_kv_schedule_orders_blocks_by_ring_hop():
+    blocks = ring_kv_schedule(
+        num_kv=10, kv_block_size=3, world_size=3, rank=1)
+
+    assert [(b.start, b.end, b.owner_rank, b.hop, b.backend) for b in blocks] == [
+        (3, 6, 1, 0, "ring"),
+        (0, 3, 0, 1, "ring"),
+        (9, 10, 0, 1, "ring"),
+        (6, 9, 2, 2, "ring"),
+    ]
+
+
+def test_usp_kv_schedule_preserves_global_block_order_with_owners():
+    blocks = usp_kv_schedule(
+        num_kv=10, kv_block_size=3, world_size=3, rank=1)
+
+    assert [(b.start, b.end, b.owner_rank, b.hop, b.backend) for b in blocks] == [
+        (0, 3, 0, 1, "usp"),
+        (3, 6, 1, 0, "usp"),
+        (6, 9, 2, 1, "usp"),
+        (9, 10, 0, 1, "usp"),
+    ]
+
+
+def test_materialize_paged_kv_trims_padding_tokens():
+    manager = SimpleCacheManager(
+        batch_size=1, page_size=4, num_kv_heads=1, head_dim=2, local_rank=0)
+    key = torch.arange(12, dtype=torch.bfloat16).view(1, 6, 1, 2)
+    value = key + 100
+    manager.update(key, value, stage=1)
+
+    key_full, value_full = materialize_paged_kv(manager)
+
+    assert key_full.shape == (1, 6, 1, 2)
+    assert value_full.shape == (1, 6, 1, 2)
+    assert torch.equal(key_full, key)
+    assert torch.equal(value_full, value)
+
+
+def test_cache_manager_exposes_global_page_indices_for_indexed_attention():
+    manager = SimpleCacheManager(
+        batch_size=1, page_size=2, num_kv_heads=1, head_dim=2, local_rank=0)
+    key = torch.arange(12, dtype=torch.bfloat16).view(1, 6, 1, 2)
+    manager.update(key, key + 100, stage=1)
+
+    page_indices = manager.page_indices_tensor(device="cpu")
+
+    assert page_indices.dtype == torch.int64
+    assert page_indices.tolist() == [0, 1, 2]
+
+    autograd_indices = manager.page_indices_tensor(
+        device="cpu", for_autograd=True)
+    assert not torch.is_inference(autograd_indices)
+    assert autograd_indices.tolist() == [0, 1, 2]
+
+
+def test_paged_rectangular_attention_returns_current_kv_grad_from_manager():
+    torch.manual_seed(2)
+    manager = SimpleCacheManager(
+        batch_size=1, page_size=2, num_kv_heads=1, head_dim=4, local_rank=0)
+    key = torch.randn(1, 4, 1, 4, dtype=torch.bfloat16)
+    value = torch.randn(1, 4, 1, 4, dtype=torch.bfloat16)
+    manager.update(key, value, stage=1)
+    query = torch.randn(1, 2, 1, 4, dtype=torch.bfloat16, requires_grad=True)
+    key_cur = key[:, 2:].detach().clone().requires_grad_(True)
+    value_cur = value[:, 2:].detach().clone().requires_grad_(True)
+    query_ref = query.detach().float().requires_grad_(True)
+    key_ref = key.detach().float().requires_grad_(True)
+    value_ref = value.detach().float().requires_grad_(True)
+
+    out = paged_rectangular_attention(
+        query, key_cur, value_cur, manager,
+        query_block_size=1,
+        kv_block_size=2,
+    )
+    ref = dense_attention_reference(
+        query_ref, key_ref, value_ref, q_start=2, kv_start=0)
+
+    out.float().square().sum().backward()
+    ref.square().sum().backward()
+
+    assert torch.allclose(out.float(), ref, atol=5e-3, rtol=5e-3)
+    assert torch.allclose(query.grad.float(), query_ref.grad, atol=5e-3, rtol=5e-3)
+    assert torch.allclose(key_cur.grad.float(), key_ref.grad[:, 2:],
+                          atol=5e-3, rtol=5e-3)
+    assert torch.allclose(value_cur.grad.float(), value_ref.grad[:, 2:],
+                          atol=5e-3, rtol=5e-3)

--- a/test_ops/test_flash_paged_attn.py
+++ b/test_ops/test_flash_paged_attn.py
@@ -1,7 +1,10 @@
 import torch
+import pytest
 from chunkoptim.ops import flash_paged_attn_func
 from chunkoptim.cache.kv_cache import CacheManagerSimple
-from flash_attn import flash_attn_func
+
+flash_attn = pytest.importorskip("flash_attn")
+flash_attn_func = flash_attn.flash_attn_func
 
 
 if __name__ == '__main__':

--- a/test_ops/test_flash_paged_sparse_attn.py
+++ b/test_ops/test_flash_paged_sparse_attn.py
@@ -1,7 +1,10 @@
 import torch
+import pytest
 from chunkoptim.cache.topk_cache import SparseCacheManager
 from chunkoptim.ops.flash_paged_topk import flash_paged_sparse_attn_func
-from flash_attn import flash_attn_func
+
+flash_attn = pytest.importorskip("flash_attn")
+flash_attn_func = flash_attn.flash_attn_func
 
 
 if __name__ == '__main__':

--- a/test_ops/test_ring_context_parallel.py
+++ b/test_ops/test_ring_context_parallel.py
@@ -1,0 +1,70 @@
+import math
+
+import torch
+
+from chunkoptim.ops.ring_context_parallel import (
+    finalize_online_attention,
+    init_online_attention_state,
+    online_attention_update,
+    ring_kv_owner,
+)
+
+
+def dense_attention(q, k, v, q_start, k_start, causal=True):
+    if q.shape[2] != k.shape[2]:
+        rep = q.shape[2] // k.shape[2]
+        k = k.repeat_interleave(rep, dim=2)
+        v = v.repeat_interleave(rep, dim=2)
+    scores = torch.einsum("bqhd,bkhd->bhqk", q.float(), k.float())
+    scores = scores / math.sqrt(q.shape[-1])
+    if causal:
+        q_pos = torch.arange(q_start, q_start + q.shape[1], device=q.device)
+        k_pos = torch.arange(k_start, k_start + k.shape[1], device=q.device)
+        scores = scores.masked_fill(
+            k_pos.view(1, 1, 1, -1) > q_pos.view(1, 1, -1, 1),
+            -float("inf"))
+    probs = torch.softmax(scores, dim=-1)
+    probs = torch.where(torch.isfinite(probs), probs, torch.zeros_like(probs))
+    return torch.einsum("bhqk,bkhd->bqhd", probs, v.float())
+
+
+def test_online_attention_update_matches_dense_attention_for_gqa():
+    torch.manual_seed(0)
+    q = torch.randn(1, 3, 4, 5, dtype=torch.bfloat16)
+    k0 = torch.randn(1, 4, 2, 5, dtype=torch.bfloat16)
+    v0 = torch.randn(1, 4, 2, 5, dtype=torch.bfloat16)
+    k1 = torch.randn(1, 5, 2, 5, dtype=torch.bfloat16)
+    v1 = torch.randn(1, 5, 2, 5, dtype=torch.bfloat16)
+
+    state = init_online_attention_state(
+        batch_size=1, q_len=3, num_heads=4, head_dim=5,
+        device=q.device, dtype=torch.float32)
+    state = online_attention_update(state, q, k0, v0, q_start=6, k_start=0)
+    state = online_attention_update(state, q, k1, v1, q_start=6, k_start=4)
+    out, lse = finalize_online_attention(state, output_dtype=torch.float32)
+
+    ref = dense_attention(
+        q, torch.cat([k0, k1], dim=1), torch.cat([v0, v1], dim=1),
+        q_start=6, k_start=0)
+    torch.testing.assert_close(out, ref, rtol=2e-2, atol=2e-2)
+    assert torch.isfinite(lse).all()
+
+
+def test_online_attention_update_keeps_empty_rows_finite():
+    q = torch.randn(1, 2, 2, 4, dtype=torch.bfloat16)
+    k = torch.randn(1, 3, 2, 4, dtype=torch.bfloat16)
+    v = torch.randn(1, 3, 2, 4, dtype=torch.bfloat16)
+    state = init_online_attention_state(
+        batch_size=1, q_len=2, num_heads=2, head_dim=4,
+        device=q.device, dtype=torch.float32)
+
+    state = online_attention_update(state, q, k, v, q_start=0, k_start=5)
+    out, lse = finalize_online_attention(state, output_dtype=torch.float32)
+
+    assert torch.equal(out, torch.zeros_like(out))
+    assert torch.equal(lse, torch.full_like(lse, -float("inf")))
+
+
+def test_ring_kv_owner_rotates_from_left_neighbor():
+    assert [ring_kv_owner(rank=3, step=i, world_size=8) for i in range(8)] == [
+        3, 2, 1, 0, 7, 6, 5, 4]

--- a/train/train.py
+++ b/train/train.py
@@ -214,7 +214,11 @@ def blockwise_tensor_parallel_sparse(model, batch, grad_ckpt, block_size, page_s
     return accum_loss
 
 
-def blockwise_tensor_parallel(model, batch, grad_ckpt, block_size, page_size, cpu_offload):
+def blockwise_tensor_parallel(
+        model, batch, grad_ckpt, block_size, page_size, cpu_offload,
+        attention_backend="paged", attention_merge_backend="allreduce",
+        attention_reduce_dtype="float32", attention_query_block_size=128,
+        attention_kv_block_size=128, attention_fallback_to_local=True):
     my_chunkize = partial(chunkize, dim=-1, chunk_size=block_size)
     input_ids = list(my_chunkize(batch['input_ids']))
     labels = list(my_chunkize(batch['labels']))
@@ -225,7 +229,15 @@ def blockwise_tensor_parallel(model, batch, grad_ckpt, block_size, page_size, cp
             batch_size=1,
             page_size=page_size,
             num_heads=model.model.config.num_key_value_heads // dist.get_world_size(),
-            cpu_offload=cpu_offload)
+            cpu_offload=cpu_offload,
+            attention_conf={
+                "backend": attention_backend,
+                "merge_backend": attention_merge_backend,
+                "reduce_dtype": attention_reduce_dtype,
+                "fallback_to_local": attention_fallback_to_local,
+                "query_block_size": attention_query_block_size,
+                "kv_block_size": attention_kv_block_size,
+            })
     dist.barrier()
     if dist.get_rank() != 0:
         kv_cache = KVCache(
@@ -233,7 +245,15 @@ def blockwise_tensor_parallel(model, batch, grad_ckpt, block_size, page_size, cp
             batch_size=1,
             page_size=page_size,
             num_heads=model.model.config.num_key_value_heads // dist.get_world_size(),
-            cpu_offload=cpu_offload)
+            cpu_offload=cpu_offload,
+            attention_conf={
+                "backend": attention_backend,
+                "merge_backend": attention_merge_backend,
+                "reduce_dtype": attention_reduce_dtype,
+                "fallback_to_local": attention_fallback_to_local,
+                "query_block_size": attention_query_block_size,
+                "kv_block_size": attention_kv_block_size,
+            })
     dist.barrier()
 
     accum_loss = 0


### PR DESCRIPTION
## Summary
- Add exact attention building blocks for long-context work: rectangular online-softmax streaming, distributed LSE output merge, KV transport schedules, and a reference ring context-parallel online attention state.
- Extend paged attention with indexed-page forward/backward plus a distributed merge entry point for KV/page-sharded exact attention experiments.
- Wire blockwise TP training to a configurable attention dispatcher: `paged` remains the default, with opt-in `distributed_paged` and `rectangular` reference backends.
- Add cache page-index metadata, public ops exports, namespace packaging, and a transformers rotary compatibility shim used by the TP modifiers.

## How to enable
For `blockwise-tp` configs, keep current behavior with no changes, or opt in with fields such as:

```json
{
  "attention_backend": "distributed_paged",
  "attention_merge_backend": "allreduce",
  "attention_reduce_dtype": "float32",
  "attention_fallback_to_local": true
}
```

The `rectangular` backend is a correctness/debug reference, not a performance backend.

## Test Plan
- `python -m pytest -q test_ops`
- `python -m py_compile setup.py train/train.py test_efficiency/test.py chunkoptim/modifiers/blockwise_attention.py chunkoptim/modifiers/train_blockwise_tp.py chunkoptim/cache/kv_cache.py chunkoptim/ops/flash_paged_attn.py`
- `git diff --check`